### PR TITLE
CPP: Add .expected file for the InitialisationNotRun test

### DIFF
--- a/cpp/ql/test/query-tests/Critical/InitialisationNotRun/InitialisationNotRun.expected
+++ b/cpp/ql/test/query-tests/Critical/InitialisationNotRun/InitialisationNotRun.expected
@@ -1,3 +1,2 @@
 | test.cpp:12:16:12:17 | g1 | Initialization code for 'g1' is never run. |
 | test.cpp:14:23:14:24 | g3 | Initialization code for 'g3' is never run. |
-| test.cpp:16:12:16:12 | a | Initialization code for 'a' is never run. |

--- a/cpp/ql/test/query-tests/Critical/InitialisationNotRun/InitialisationNotRun.expected
+++ b/cpp/ql/test/query-tests/Critical/InitialisationNotRun/InitialisationNotRun.expected
@@ -1,0 +1,3 @@
+| test.cpp:12:16:12:17 | g1 | Initialization code for 'g1' is never run. |
+| test.cpp:14:23:14:24 | g3 | Initialization code for 'g3' is never run. |
+| test.cpp:16:12:16:12 | a | Initialization code for 'a' is never run. |

--- a/cpp/ql/test/query-tests/Critical/InitialisationNotRun/test.cpp
+++ b/cpp/ql/test/query-tests/Critical/InitialisationNotRun/test.cpp
@@ -1,4 +1,8 @@
-#include <string.h>
+// --- stubs ---
+
+char *strcpy(char *dest, const char *src);
+
+// --- tests ---
 
 class GlobalStorage {
 public:


### PR DESCRIPTION
Creates a `.expected` file for the new InitialisationNotRun test in https://github.com/github/codeql/pull/20129.  Also replaces the `#include <string>` in the test source with a stub, since CPP QL tests are not supposed to depend on any libraries.

@codeqlhelper - if you're happy with these changes just hit merge on this PR and it'll be merged into yours (then fetch the branch from `origin` on your local machine if you intend to make further changes).